### PR TITLE
Remove bucketName because it leads to errors

### DIFF
--- a/src/main/java/com/example/iac/PipelineStack.java
+++ b/src/main/java/com/example/iac/PipelineStack.java
@@ -62,12 +62,16 @@ public class PipelineStack extends Stack {
         IRepository gitRepo =   props.getGitRepo();
 
         //creating the ECR Repository
-        software.amazon.awscdk.services.ecr.Repository repo =   software.amazon.awscdk.services.ecr.Repository.Builder.create(this, appName+"-ecr").repositoryName(appName+"").build();
-        repo.applyRemovalPolicy(RemovalPolicy.DESTROY);
+        software.amazon.awscdk.services.ecr.Repository repo =   software.amazon.awscdk.services.ecr.Repository.Builder.create(this, appName+"-ecr")
+        .repositoryName(appName+"")
+        .removalPolicy(RemovalPolicy.DESTROY)
+        .build();
 
         //pipeline bucket
-        Bucket pipelineBucket = Bucket.Builder.create(this, "pipeline-staging-"+appName).bucketName("codepipeline-staging-"+appName).encryption(BucketEncryption.S3_MANAGED).build();
-        pipelineBucket.applyRemovalPolicy(RemovalPolicy.DESTROY);
+        Bucket pipelineBucket = Bucket.Builder.create(this, "pipeline-staging-" + appName)
+                .encryption(BucketEncryption.S3_MANAGED)
+                .removalPolicy(RemovalPolicy.DESTROY)
+                .build();
 
         //pipeline
         Role deployRole         =   createCodeDeployExecutionRole(appName, props);


### PR DESCRIPTION
It seems that `String appName      =   this.getNode().getAddr().substring(0, 10);`  creates an ID that is not unique between instances of CDK apps. In other words: For me the `codepipeline-staging-"+appName"` bucket caused a collision with an existing bucket which wasn't in my account, most probably yours @ldecaro ;)

This commit removes the bucketName, in line with what you did for `GitSeedBucket`. This resolved my issue.

Additionally this commit just pulls the removalPolicy into the Builder.